### PR TITLE
Small fixes to Gumbo usage

### DIFF
--- a/html2cmark.lua
+++ b/html2cmark.lua
@@ -325,22 +325,9 @@ end
 
 local M = {}
 
-local function lookup_attr(node, name)
-  local attributes = node.attributes
-  if not attributes then
-    return nil
-  end
-  for _,attr in ipairs(node.attributes) do
-   if attr.name == name then
-     return attr.value
-   end
-  end
-  return nil
-end
-
 local function get_content_node(node)
   if node.nodeName == 'MAIN' or
-     (node.nodeName == 'DIV' and lookup_attr(node, 'id') == 'content') then
+     (node.nodeName == 'DIV' and node.id == 'content') then
     return node
   else
     for _,n in ipairs(node.childNodes) do
@@ -356,7 +343,7 @@ end
 function M.parse_html(htmlstring, opts)
 
   local html, msg
-  html, msg = gumbo.parse(htmlstring, 4, 'HTML')
+  html, msg = gumbo.parse(htmlstring, 4, 'BODY')
   if not html then
     return nil, msg
   end

--- a/rockspec.in
+++ b/rockspec.in
@@ -17,7 +17,7 @@ description = {
 dependencies = {
    "lua >= 5.2",
    "cmark >= 0.24",
-   "gumbo >= 0.4",
+   "gumbo >= 0.5",
    "optparse >= 1.0.1",
 }
 build = {


### PR DESCRIPTION
Changes:

* Using `BODY` instead of `HTML` as the fragment context seems to make 3 more spec tests pass -- doing this prevents any parsing quirks related to the `<head>` element from coming into play and seems to be the desired behaviour for this use case
* The [`Element.id`](https://craigbarnes.gitlab.io/lua-gumbo/#element) property can be used to get the same result as `lookup_attr(node, 'id')`
* Updates `rockspec.in` to use [lua-gumbo 0.5](https://github.com/craigbarnes/lua-gumbo/releases/tag/0.5), which has quite a few bug fixes and no longer requires an external libgumbo installation

I get 93 test failures after these changes (96 before). Are those expected? Many of them seem like whitespace differences.